### PR TITLE
fix(relayer): correct mainnet DEEP coin type to fix swap 500 errors

### DIFF
--- a/frontend/src/hooks/usePoolInfo.ts
+++ b/frontend/src/hooks/usePoolInfo.ts
@@ -36,6 +36,11 @@ export function usePoolInfo(poolId: string) {
     let isCancelled = false;
 
     async function fetchPoolInfo() {
+      if (!poolId) {
+        setLoading(false);
+        return;
+      }
+
       try {
         setLoading(true);
         setError(null);

--- a/relayer/config/relayer-config.ts
+++ b/relayer/config/relayer-config.ts
@@ -34,7 +34,7 @@ const NETWORK_DEFAULTS: Record<Network, NetworkDefaults> = {
   mainnet: {
     rpcUrl: "https://fullnode.mainnet.sui.io",
     deepCoinType:
-      "0xdeeb7a4662eec9f2f3def03fb937a663dddaa2e215b8078a284d026b7946501f::deep::DEEP",
+      "0xdeeb7a4662eec9f2f3def03fb937a663dddaa2e215b8078a284d026b7946c270::deep::DEEP",
     poolEnvVars: [
       "MAINNET_SUI_POOL_ID",
       "MAINNET_USDC_POOL_ID",
@@ -103,7 +103,7 @@ export function loadNetworkConfig(network: Network): RelayerConfig {
       ...defaults.nativeTokenTypes,
       ...collectEnvValues(defaults.tokenTypeEnvVars),
     ],
-    deepCoinType: defaults.deepCoinType,
+    deepCoinType: process.env[`${networkKey}_DEEP_TYPE`] ?? defaults.deepCoinType,
     estimatedDeepFee: 10_000n,
     allowedPools: new Set(collectEnvValues(defaults.poolEnvVars)),
     allowedDeepbookPools: new Set(collectEnvValues(defaults.deepbookPoolEnvVars)),

--- a/relayer/src/server.ts
+++ b/relayer/src/server.ts
@@ -112,8 +112,9 @@ async function main(): Promise<void> {
       const txHash = await relayer.submitTransfer(parsed.data);
       res.json({ txHash });
     } catch (err) {
+      const message = err instanceof Error ? err.message : "Submission failed";
       console.error("[transfer] Submission error:", err);
-      res.status(500).json({ error: "Submission failed" });
+      res.status(500).json({ error: message });
     }
   });
 
@@ -133,8 +134,9 @@ async function main(): Promise<void> {
       const txHash = await relayer.submitUnshield(parsed.data);
       res.json({ txHash });
     } catch (err) {
+      const message = err instanceof Error ? err.message : "Submission failed";
       console.error("[unshield] Submission error:", err);
-      res.status(500).json({ error: "Submission failed" });
+      res.status(500).json({ error: message });
     }
   });
 
@@ -154,8 +156,9 @@ async function main(): Promise<void> {
       const txHash = await relayer.submitSwap(parsed.data);
       res.json({ txHash });
     } catch (err) {
+      const message = err instanceof Error ? err.message : "Submission failed";
       console.error("[swap] Submission error:", err);
-      res.status(500).json({ error: "Submission failed" });
+      res.status(500).json({ error: message });
     }
   });
 


### PR DESCRIPTION
## Summary

- **Root cause**: The relayer had a wrong hardcoded mainnet DEEP coin type (`...7946501f`) that differs from the actual Sui mainnet DEEP token (`...7946c270`). This caused `getCoins()` to return 0 results, triggering "Relayer has no DEEP tokens" → 500 on every mainnet swap.
- Fix the hardcoded fallback to the correct package ID suffix (`c270`)
- Make `deepCoinType` overridable via `MAINNET_DEEP_TYPE` / `TESTNET_DEEP_TYPE` env vars (already used for `supportedTokens`, now also drives coin type lookup)
- Guard `usePoolInfo` against empty `poolId` to suppress "Invalid Sui Object id" console errors when no token is selected
- Pass actual exception messages through relayer 500 responses instead of a generic "Submission failed" string

## Test plan

- [ ] Deploy updated relayer to `relayer.sui-octopus.com`
- [ ] Confirm relayer wallet holds mainnet DEEP tokens of type `...c270::deep::DEEP`
- [ ] Connect wallet on mainnet, open Swap tab (SUI → USDC), submit — should succeed
- [ ] Confirm no "Invalid Sui Object id" errors in browser console on mainnet
- [ ] Confirm 500 responses now include the real error message (e.g. pool validation failures show descriptive text)