### PR TITLE
ci: restrict code review to PRs targeting main branch

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,8 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    branches:
+      - main
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Summary

- Add `branches: [main]` filter to `claude-code-review.yml` so the Claude Code Review CI only runs on PRs targeting `main`
- Remove the unused `paths` example comments

## Test plan

- [ ] Open a PR targeting `main` — CI should trigger
- [ ] Open a PR targeting any other branch (e.g. `dev`) — CI should NOT trigger