### PR TITLE
fix(relayer): fix CORS origin and add Railway deployment config

### DIFF
--- a/relayer/.env.example
+++ b/relayer/.env.example
@@ -3,7 +3,7 @@
 # production (NODE_ENV=production). This is intentional. To test the relayer from the command line
 # in a staging environment, either set NODE_ENV=development or add a reverse-proxy that injects an
 # allowed Origin header.
-ALLOWED_ORIGINS=http://localhost:3000,https://sui-octopus.com,https://dev.sui-octopus.com
+ALLOWED_ORIGINS=http://localhost:3000,https://www.sui-octopus.com,https://dev.sui-octopus.com
 
 # Server-side Ed25519 private keys (hex or base64)
 # Generate with: sui client new-address ed25519

--- a/relayer/railway.toml
+++ b/relayer/railway.toml
@@ -1,0 +1,10 @@
+[build]
+builder = "nixpacks"
+buildCommand = "npm ci && npm run build"
+
+[deploy]
+startCommand = "npm start"
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3

--- a/relayer/src/server.ts
+++ b/relayer/src/server.ts
@@ -58,6 +58,11 @@ async function main(): Promise<void> {
     legacyHeaders: false,
   });
 
+  // GET /health
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok" });
+  });
+
   // GET /relayer-info
   app.get("/relayer-info", infoLimiter, (_req, res) => {
     const info: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary

- Fix CORS: update `ALLOWED_ORIGINS` from `https://sui-octopus.com` to `https://www.sui-octopus.com` to match actual frontend origin
- Add `GET /health` endpoint for Railway health checks
- Add `railway.toml` to ensure Railway runs `npm install && npm run build` before starting, with proper healthcheck config

## Root Cause

Two issues were blocking the production relayer:
1. **CORS rejection**: The frontend at `https://www.sui-octopus.com` (with `www.`) was not in `ALLOWED_ORIGINS`, causing Express to reject requests and return no CORS headers
2. **404 / startup failure**: Without `railway.toml`, Railway may skip the build step, leaving `dist/` missing and causing `npm start` to fail — resulting in Railway's proxy returning 404

## Test plan

- [ ] Push to Railway triggers a fresh build (`npm install && npm run build`)
- [ ] `curl https://relayer.sui-octopus.com/health` returns `{"status":"ok"}`
- [ ] `curl https://relayer.sui-octopus.com/relayer-info` returns JSON
- [ ] Frontend RelayerSelector at `https://www.sui-octopus.com` shows relayer connected
- [ ] Update `ALLOWED_ORIGINS=https://www.sui-octopus.com` in Railway Dashboard env vars